### PR TITLE
[BUG] TopSky + GroundRadar Colour bug fix

### DIFF
--- a/geojson_to_topsky_groundradar.py
+++ b/geojson_to_topsky_groundradar.py
@@ -22,7 +22,7 @@ MAP:
 FOLDER:
 LAYER:
 ACTIVE:1
-COLOR:TWY    
+COLOR:TWY 
 '''
 
 	gr_header = '''MAP:

--- a/geojson_to_topsky_groundradar.py
+++ b/geojson_to_topsky_groundradar.py
@@ -22,7 +22,7 @@ MAP:
 FOLDER:
 LAYER:
 ACTIVE:1
-COLOR:TWY 
+COLOR:TWY
 '''
 
 	gr_header = '''MAP:


### PR DESCRIPTION
## Description

This PR fixes a bug which causes TopSky and GroundRadar to invalidate the colors result in an all-black ground layout. 

For example:  
this causes an error: `COLOR:BACKGROUND `  
but this does not: `COLOR:BACKGROUND`

## Issue
fixes #7 

## Known Issues
-

## Documentation
-