### PR TITLE
Fixed taxiway splitting: taxiway variable not yet created

### DIFF
--- a/split_taxiway_algorithm.py
+++ b/split_taxiway_algorithm.py
@@ -42,6 +42,7 @@ class SplitTaxiwayAlgorithm(QgsProcessingAlgorithm):
 
 		discovered_taxiway_ref_codes = []
 		ref_layers = []
+		taxiway = False
 		
 		for layer_feature in layer.getFeatures():
 			


### PR DESCRIPTION
### Linked Issue

closes #31 

### Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)
- [ ] 📜 Documentation

### Description

Fixes the split taxiway bug by adding the taxiway variable beforehand and initializing it to false.