### PR TITLE
Reverted crashing behaviour by setting feature_types = []

### DIFF
--- a/fetch_osm_data_algorithm.py
+++ b/fetch_osm_data_algorithm.py
@@ -188,7 +188,7 @@ class FetchOSMDataAlgorithm(QgsProcessingAlgorithm):
 		# Send the request
 		url = "https://overpass-api.de/api/interpreter"
 		response = requests.get(url, params={"data": query})
-		feature_types = self.FEATURE_TYPES
+		feature_types = []
 
 		if response.status_code == 200:
 			data = response.json()


### PR DESCRIPTION
### Linked Issue

closes #46 

### Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)
- [ ] 📜 Documentation

### Description

Fixes the issue by assigning feature_types to an empty list which prevents searching all feature types, even when they're not situated at the AD if the Overpass search yields empty results without error.